### PR TITLE
Add simplified key hasher

### DIFF
--- a/src/torch_max_mem/api.py
+++ b/src/torch_max_mem/api.py
@@ -215,6 +215,8 @@ class MemoryUtilizationMaximizer:
             Whether to check the input for CPU tensors and warn about potential CPU OOM problems.
         :param hasher:
             a hashing function for separate parameter values depending on hash value; if None, use the same for all
+        :param keys:
+            the keys to use for creating a hasher. Only used if hasher is None.
         """
         self.parameter_name = parameter_name
         self.q = q

--- a/src/torch_max_mem/version.py
+++ b/src/torch_max_mem/version.py
@@ -38,4 +38,4 @@ def get_version(with_git_hash: bool = False):
 
 
 if __name__ == "__main__":
-    print(get_version(with_git_hash=True))  # noqa:T001
+    print(get_version(with_git_hash=True))  # noqa:T201


### PR DESCRIPTION
This PR adds a simplification for creating hashers based on the values associated to a subse of keys without having to define a lambda or named function.