### PR TITLE
Extend CUDA OOM Handling

### DIFF
--- a/src/torch_max_mem/api.py
+++ b/src/torch_max_mem/api.py
@@ -289,8 +289,11 @@ def maximize_memory_utilization_decorator(
                         )
                     except (torch.cuda.OutOfMemoryError, RuntimeError) as error:
                         # check for additional OOM error types
-                        if isinstance(error, RuntimeError) and not any(
-                            infix in error.args[0] for infix in ADDITIONAL_OOM_ERROR_INFIXES
+                        if not isinstance(error, torch.cuda.OutOfMemoryError) and (
+                            not error.args
+                            or not any(
+                                infix in error.args[0] for infix in ADDITIONAL_OOM_ERROR_INFIXES
+                            )
                         ):
                             raise error
 

--- a/src/torch_max_mem/api.py
+++ b/src/torch_max_mem/api.py
@@ -177,7 +177,7 @@ def determine_max_value(
 # cf. https://github.com/pykeen/pykeen/pull/279
 ADDITIONAL_OOM_ERROR_INFIXES = {
     # An error that occurs because the input in CUDA is too big.
-    # cf. https://discuss.pytorch.org/t/cudnn-status-not-supported-this-error-may-appear-if-you-passed-in-a-non-contiguous-input/68826
+    # cf. https://discuss.pytorch.org/t/cudnn-status-not-supported-this-error-may-appear-if-you-passed-in-a-non-contiguous-input/  # noqa: E501
     "cuDNN error: CUDNN_STATUS_NOT_SUPPORTED. This error may appear if you passed in a non-contiguous input.",
     # The torch < 2.0 way of OOM errors
     "CUDA out of memory.",
@@ -258,6 +258,8 @@ def maximize_memory_utilization_decorator(
 
             :raises MemoryError:
                 if the execution did not even succeed with the smallest parameter value
+            :raises RuntimeError:
+                if a runtime error which is unrelated to known OOM errors occurred
             """
             check_for_cpu_tensors(*args, **kwargs)
             bound_arguments = signature.bind(*args, **kwargs)

--- a/src/torch_max_mem/api.py
+++ b/src/torch_max_mem/api.py
@@ -289,12 +289,10 @@ def maximize_memory_utilization_decorator(
                         )
                     except (torch.cuda.OutOfMemoryError, RuntimeError) as error:
                         # check for additional OOM error types
-                        if isinstance(error, RuntimeError):
-                            for infix in ADDITIONAL_OOM_ERROR_INFIXES:
-                                if infix in error.args[0]:
-                                    break
-                            else:  # none matched -> this is a different error
-                                raise error
+                        if isinstance(error, RuntimeError) and not any(
+                            infix in error.args[0] for infix in ADDITIONAL_OOM_ERROR_INFIXES
+                        ):
+                            raise error
 
                         # clear cache
                         torch.cuda.empty_cache()


### PR DESCRIPTION
This PR handles a few additional errors as `torch.cuda.OutOfMemoryError`, cf. https://github.com/pykeen/pykeen/pull/279

```
cuDNN error: CUDNN_STATUS_NOT_SUPPORTED. This error may appear if you passed in a non-contiguous input.
```
cf. https://discuss.pytorch.org/t/cudnn-status-not-supported-this-error-may-appear-if-you-passed-in-a-non-contiguous-input/

```
CUDA out of memory.
```
(this was the torch < 2.0 way of OOM errors)

```
nonzero is not supported for tensors with more than INT_MAX elements
```
cf. https://github.com/pytorch/pytorch/issues/51871
