### PR TITLE
Refactoring towards MPS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ from torch_max_mem import maximize_memory_utilization
 def knn(x, y, batch_size, k: int = 3):
     return torch.cat(
         [
-            torch.cdist(x[start : start + batch_size], y).topk(k=k, dim=0, largest=False).indices
+            torch.cdist(x[start : start + batch_size], y).topk(k=k, dim=1, largest=False).indices
             for start in range(0, x.shape[0], batch_size)
         ],
         dim=0,

--- a/src/torch_max_mem/api.py
+++ b/src/torch_max_mem/api.py
@@ -372,6 +372,9 @@ def maximize_memory_utilization_decorator(
                         # clear cache
                         if torch.cuda.is_available():
                             torch.cuda.empty_cache()
+                        if hasattr(torch, "mps"):
+                            # there is no torch.mps.is_available()
+                            torch.mps.empty_cache()
 
                         # reduce parameter
                         logger.info(f"Execution failed with {p_kwargs=}")

--- a/src/torch_max_mem/api.py
+++ b/src/torch_max_mem/api.py
@@ -182,8 +182,8 @@ ADDITIONAL_OOM_ERROR_INFIXES = {
     # An error that occurs because the input in CUDA is too big.
     # cf. https://discuss.pytorch.org/t/cudnn-status-not-supported-this-error-may-appear-if-you-passed-in-a-non-contiguous-input/  # noqa: E501
     "cuDNN error: CUDNN_STATUS_NOT_SUPPORTED. This error may appear if you passed in a non-contiguous input.",
-    # note: this should catch "MPS backend out of memory" as well as the torch <2.0 "CUDA out of memory"
-    "out of memory",
+    # The torch < 2.0 way of OOM errors
+    "CUDA out of memory.",
     # cf. https://github.com/pytorch/pytorch/issues/51871
     "nonzero is not supported for tensors with more than INT_MAX elements",
     # cf. https://discuss.pytorch.org/t/runtime-error-invalid-buffer-size-when-calculating-cosine-similarity/152088

--- a/src/torch_max_mem/api.py
+++ b/src/torch_max_mem/api.py
@@ -220,18 +220,18 @@ def create_tensor_checker(safe_devices: Collection[str] | None = None) -> Callab
     """
     if safe_devices is None:
         safe_devices = {"cuda"}
-    safe_devices = frozenset(safe_devices)
+    safe_devices_set = frozenset(safe_devices)
     logger.debug(
-        f"Will warn about running memory utilization maximization on tensors on devices other than {safe_devices}",
+        f"Will warn about running memory utilization maximization on tensors on devices other than {safe_devices_set}",
     )
 
     def check_tensors(*args, **kwargs) -> None:
         """Check whether any tensor argument is on a dangerous device."""
         device_types = {device.type for device in iter_tensor_devices(*args, **kwargs)}
 
-        if not safe_devices.issuperset(device_types):
+        if not safe_devices_set.issuperset(device_types):
             logger.warning(
-                f"Encountered tensors on {device_types=} while only {sorted(safe_devices)} are considered safe for "
+                f"Encountered tensors on {device_types=} while only {sorted(safe_devices_set)} are considered safe for "
                 f"automatic memory utilization maximization. This may lead to undocumented crashes (but can be safe, "
                 f"too).",
             )

--- a/src/torch_max_mem/api.py
+++ b/src/torch_max_mem/api.py
@@ -188,6 +188,10 @@ ADDITIONAL_OOM_ERROR_INFIXES = {
     "nonzero is not supported for tensors with more than INT_MAX elements",
     # cf. https://discuss.pytorch.org/t/runtime-error-invalid-buffer-size-when-calculating-cosine-similarity/152088
     "Invalid buffer size: ",
+    # MPS OOM error
+    "MPS backend out of memory",
+    # CPU OOM error
+    "DefaultCPUAllocator: not enough memory:",
 }
 
 

--- a/src/torch_max_mem/api.py
+++ b/src/torch_max_mem/api.py
@@ -182,8 +182,8 @@ ADDITIONAL_OOM_ERROR_INFIXES = {
     # An error that occurs because the input in CUDA is too big.
     # cf. https://discuss.pytorch.org/t/cudnn-status-not-supported-this-error-may-appear-if-you-passed-in-a-non-contiguous-input/  # noqa: E501
     "cuDNN error: CUDNN_STATUS_NOT_SUPPORTED. This error may appear if you passed in a non-contiguous input.",
-    # The torch < 2.0 way of OOM errors
-    "CUDA out of memory.",
+    # note: this should catch "MPS backend out of memory" as well as the torch <2.0 "CUDA out of memory"
+    "out of memory",
     # cf. https://github.com/pytorch/pytorch/issues/51871
     "nonzero is not supported for tensors with more than INT_MAX elements",
     # cf. https://discuss.pytorch.org/t/runtime-error-invalid-buffer-size-when-calculating-cosine-similarity/152088

--- a/src/torch_max_mem/api.py
+++ b/src/torch_max_mem/api.py
@@ -69,14 +69,6 @@ from typing import (
 import torch
 from typing_extensions import ParamSpec
 
-try:
-    import torch.mps
-except ImportError:
-    mps_available = False
-else:
-    mps_available = True
-
-
 logger = logging.getLogger(__name__)
 
 __all__ = [
@@ -380,7 +372,8 @@ def maximize_memory_utilization_decorator(
                         # clear cache
                         if torch.cuda.is_available():
                             torch.cuda.empty_cache()
-                        if mps_available:
+                        # https://pytorch.org/docs/stable/notes/mps.html
+                        if torch.backends.mps.is_available():
                             # there is no torch.mps.is_available()
                             torch.mps.empty_cache()
 

--- a/src/torch_max_mem/api.py
+++ b/src/torch_max_mem/api.py
@@ -52,6 +52,7 @@ import functools
 import inspect
 import itertools
 import logging
+from collections import ChainMap
 from typing import (
     Any,
     Callable,
@@ -359,7 +360,8 @@ def maximize_memory_utilization_decorator(
                     p_kwargs = {
                         name: max_value for name, max_value in zip(parameter_names, max_values)
                     }
-                    combined_kwargs: P.kwargs = {**p_kwargs, **bound_arguments.kwargs}
+                    # note: bound_arguments.kwargs is typed as dict, but (silently) immutable (=ignoring updates)...
+                    combined_kwargs: P.kwargs = ChainMap(p_kwargs, bound_arguments.kwargs)
                     try:
                         return func(*bound_arguments.args, **combined_kwargs), tuple(max_values)
                     except (torch.cuda.OutOfMemoryError, RuntimeError) as error:

--- a/src/torch_max_mem/api.py
+++ b/src/torch_max_mem/api.py
@@ -30,7 +30,7 @@ out-of-memory error occurs.
     def knn(x, y, batch_size, k: int = 3):
         return torch.cat(
             [
-                torch.cdist(x[start : start + batch_size], y).topk(k=k, dim=0, largest=False).indices
+                torch.cdist(x[start : start + batch_size], y).topk(k=k, dim=1, largest=False).indices
                 for start in range(0, x.shape[0], batch_size)
             ],
             dim=0,

--- a/src/torch_max_mem/api.py
+++ b/src/torch_max_mem/api.py
@@ -224,8 +224,9 @@ def create_tensor_checker(safe_devices: Collection[str] | None = None) -> Callab
 
         if not safe_devices.issuperset(device_types):
             logger.warning(
-                f"Encountered tensors on {device_types=} while only {safe_devices=} are considered safe for automatic"
-                f"memory utilization maximization. This may lead to undocumented crashes (but can be safe, too).",
+                f"Encountered tensors on {device_types=} while only {sorted(safe_devices)} are considered safe for "
+                f"automatic memory utilization maximization. This may lead to undocumented crashes (but can be safe, "
+                f"too).",
             )
 
     return check_tensors

--- a/src/torch_max_mem/api.py
+++ b/src/torch_max_mem/api.py
@@ -69,6 +69,14 @@ from typing import (
 import torch
 from typing_extensions import ParamSpec
 
+try:
+    import torch.mps
+except ImportError:
+    mps_available = False
+else:
+    mps_available = True
+
+
 logger = logging.getLogger(__name__)
 
 __all__ = [
@@ -372,7 +380,7 @@ def maximize_memory_utilization_decorator(
                         # clear cache
                         if torch.cuda.is_available():
                             torch.cuda.empty_cache()
-                        if hasattr(torch, "mps"):
+                        if mps_available:
                             # there is no torch.mps.is_available()
                             torch.mps.empty_cache()
 

--- a/src/torch_max_mem/api.py
+++ b/src/torch_max_mem/api.py
@@ -186,6 +186,8 @@ ADDITIONAL_OOM_ERROR_INFIXES = {
     "CUDA out of memory.",
     # cf. https://github.com/pytorch/pytorch/issues/51871
     "nonzero is not supported for tensors with more than INT_MAX elements",
+    # cf. https://discuss.pytorch.org/t/runtime-error-invalid-buffer-size-when-calculating-cosine-similarity/152088
+    "Invalid buffer size: ",
 }
 
 

--- a/src/torch_max_mem/api.py
+++ b/src/torch_max_mem/api.py
@@ -236,6 +236,24 @@ def create_tensor_checker(safe_devices: Collection[str] | None = None) -> Callab
     return check_tensors
 
 
+def floor_to_nearest_multiple_of(x: int, q: int) -> int:
+    """
+    Try to ensure that x is a multiple of q.
+
+    :param x:
+        the input value
+    :param q:
+        the desired base factor
+
+    :return:
+        x if x is smaller than q, otherwise, the largest multiple of q that is smaller than x
+    """
+    if x <= q:
+        return x
+    # note: the brackets are for readability only
+    return (x // q) * q
+
+
 def maximize_memory_utilization_decorator(
     parameter_name: str | Sequence[str] = "batch_size",
     q: int | Sequence[int] = 32,
@@ -338,11 +356,7 @@ def maximize_memory_utilization_decorator(
 
                         # reduce parameter
                         logger.info(f"Execution failed with {p_kwargs=}")
-                        max_values[i] //= 2
-
-                        # ensure multiple of qs while possible
-                        if max_values[i] > qs[i]:
-                            max_values[i] = max_values[i] // qs[i] * qs[i]
+                        max_values[i] = floor_to_nearest_multiple_of(x=max_values[i] // 2, q=qs[i])
 
                         # update last error
                         last_error = error

--- a/src/torch_max_mem/api.py
+++ b/src/torch_max_mem/api.py
@@ -370,7 +370,8 @@ def maximize_memory_utilization_decorator(
                             raise error
 
                         # clear cache
-                        torch.cuda.empty_cache()
+                        if torch.cuda.is_available():
+                            torch.cuda.empty_cache()
 
                         # reduce parameter
                         logger.info(f"Execution failed with {p_kwargs=}")

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -10,7 +10,7 @@ import pytest
 import torch
 
 from torch_max_mem import maximize_memory_utilization
-from torch_max_mem.api import maximize_memory_utilization_decorator
+from torch_max_mem.api import maximize_memory_utilization_decorator, floor_to_nearest_multiple_of
 
 
 def knn(x, y, batch_size, k: int = 3):
@@ -114,3 +114,15 @@ def test_optimization_multi_level():
         return batch_size, slice_size
 
     assert func() == (1, 8)
+
+
+@pytest.mark.parametrize("x,q", [(15, 4), (3, 4)])
+def test_floor_to_nearest_multiple_of(x: int, q: int) -> None:
+    """Test floor_to_nearest_multiple_of."""
+    r = floor_to_nearest_multiple_of(x=x, q=q)
+    # check type
+    assert isinstance(r, int)
+    # check flooring
+    assert r <= x
+    # check multiple of q if possible
+    assert r < q or (r % q == 0)

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -130,6 +130,8 @@ def test_floor_to_nearest_multiple_of(x: int, q: int) -> None:
     assert r <= x
     # check multiple of q if possible
     assert r < q or (r % q == 0)
+    # check maximality
+    assert r + q > x
 
 
 @pytest.mark.parametrize(

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -32,11 +32,12 @@ class TestDecorator(unittest.TestCase):
     """Test the decorator."""
 
     device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+    rng = torch.random.manual_seed(seed=42)
 
     def test_knn(self):
         """Test consistent results between original and wrapped method."""
-        x = torch.rand(100, 100, device=self.device)
-        y = torch.rand(200, 100, device=self.device)
+        x = torch.rand(100, 100, device=self.device, generator=self.rng)
+        y = torch.rand(200, 100, device=self.device, generator=self.rng)
         for batch_size in [1, 10, x.shape[0]]:
             numpy.testing.assert_array_equal(
                 knn(x, y, batch_size).numpy(),
@@ -45,8 +46,8 @@ class TestDecorator(unittest.TestCase):
 
     def test_knn_stateful(self):
         """Test consistent results between original and wrapped method for stateful wrapper."""
-        x = torch.rand(100, 100, device=self.device)
-        y = torch.rand(200, 100, device=self.device)
+        x = torch.rand(100, 100, device=self.device, generator=self.rng)
+        y = torch.rand(200, 100, device=self.device, generator=self.rng)
         for batch_size in [1, 10, x.shape[0]]:
             numpy.testing.assert_array_equal(
                 knn(x, y, batch_size).numpy(),

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -11,9 +11,9 @@ import torch
 
 from torch_max_mem import maximize_memory_utilization
 from torch_max_mem.api import (
-    maximize_memory_utilization_decorator,
     floor_to_nearest_multiple_of,
     is_oom_error,
+    maximize_memory_utilization_decorator,
 )
 
 


### PR DESCRIPTION
This PR treats `mps` like `cpu`, i.e., when warnings are enabled, it will warn about running memory utilization maximization on `mps` tensors.

It also:
- fixes the knn example
- catches CPU OOM errors (as long as they are a `RuntimeError`)
- extracts a few utility functions improving documentation and testing
- makes sure to include the last exception into the stacktrace when finally giving up with a `MemoryError`
- fixes the random seed for reproducible tests

As of now, the actual optimization does not seem to work for `mps`.