### PR TITLE
Modernize

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.8", "3.11" ]
+        python-version: [ "3.9", "3.13" ]
     steps:
       - uses: actions/checkout@v4
 
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.11" ]
+        python-version: [ "3.12" ]
     steps:
     - uses: actions/checkout@v4
     
@@ -64,11 +64,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ "3.8", "3.11" ]
-        exclude:
-          # 3.8 is not available for M1 macOS
-          - os: macos-14
-            python-version: "3.8"
+        python-version: [ "3.9", "3.13" ]
     needs:
       - lint
     steps:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ build:
   image: latest
 
 python:
-  version: "3.8"
+  version: "3.12"
   install:
     - method: pip
       path: .

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,6 +38,17 @@ version = parsed_version.expand(r"\g<major>.\g<minor>.\g<patch>")
 if parsed_version.group("release"):
     tags.add("prerelease")  # noqa:F821
 
+# See https://about.readthedocs.com/blog/2024/07/addons-by-default/
+# Define the canonical URL if you are using a custom domain on Read the Docs
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# See https://about.readthedocs.com/blog/2024/07/addons-by-default/
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    if "html_context" not in globals():
+        html_context = {}
+    html_context["READTHEDOCS"] = True
+
 # -- General configuration ---------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
 tests = [
     "pytest",
     "coverage[toml]",
-    "numpy",  # needed for csrc tensors?
+    "numpy",  # optionally used for csrc tensors
 ]
 docs = [
     "sphinx>=8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,11 @@ classifiers = [
     "Framework :: tox",
     "Framework :: Sphinx",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     # TODO add your topics from the Trove controlled vocabulary (see https://pypi.org/classifiers)
 ]
@@ -41,10 +42,10 @@ keywords = [
 # See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license
 license = { file = "License" }
 
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "torch>=2.0",
-    "torch<2.4; platform_system=='Windows'",
+    # "torch<2.4; platform_system=='Windows'",
     "typing_extensions",
 ]
 
@@ -52,12 +53,9 @@ dependencies = [
 tests = ["pytest", "coverage"]
 docs = [
     # Sphinx >= 8.0 not supported by rtd theme, cf. https://github.com/readthedocs/sphinx_rtd_theme/issues/1582
-    "sphinx<8",
+    "sphinx>=8",
     "sphinx-rtd-theme",
     "sphinx_automodapi",
-    # To include LaTeX comments easily in your docs.
-    # If you uncomment this, don't forget to do the same in docs/conf.py
-    # texext
 ]
 
 [project.urls]
@@ -104,17 +102,6 @@ exclude_lines = [
     "def __repr__",
 ]
 
-[tool.black]
-line-length = 120
-target-version = ["py38", "py39", "py310", "py311", "py312"]
-
-[tool.isort]
-profile = "black"
-multi_line_output = 3
-line_length = 120
-include_trailing_comma = true
-reverse_relative = true
-
 [tool.ruff]
 line-length = 120
 
@@ -133,7 +120,7 @@ extend-select = [
     "B",   # bugbear
     "T20", # print
     "PT",  # pytest-style
-    "RSE", #raise
+    "RSE", # raise
     "SIM", # simplify
     "ERA", # eradicate commented out code
     "NPY", # numpy checks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-tests = ["pytest", "coverage[toml]"]
+tests = [
+    "pytest",
+    "coverage[toml]",
+    "numpy",  # needed for csrc tensors?
+]
 docs = [
     "sphinx>=8",
     "sphinx-rtd-theme",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,14 +45,12 @@ license = { file = "License" }
 requires-python = ">=3.9"
 dependencies = [
     "torch>=2.0",
-    # "torch<2.4; platform_system=='Windows'",
     "typing_extensions",
 ]
 
 [project.optional-dependencies]
-tests = ["pytest", "coverage"]
+tests = ["pytest", "coverage[toml]"]
 docs = [
-    # Sphinx >= 8.0 not supported by rtd theme, cf. https://github.com/readthedocs/sphinx_rtd_theme/issues/1582
     "sphinx>=8",
     "sphinx-rtd-theme",
     "sphinx_automodapi",

--- a/src/torch_max_mem/__init__.py
+++ b/src/torch_max_mem/__init__.py
@@ -1,9 +1,8 @@
-
 """Maximize memory utilization with PyTorch."""
 
 from .api import MemoryUtilizationMaximizer, maximize_memory_utilization
 
 __all__ = [
-    "maximize_memory_utilization",
     "MemoryUtilizationMaximizer",
+    "maximize_memory_utilization",
 ]

--- a/src/torch_max_mem/api.py
+++ b/src/torch_max_mem/api.py
@@ -51,14 +51,10 @@ import functools
 import inspect
 import itertools
 import logging
+from collections.abc import Collection, Iterable, Mapping, MutableMapping, Sequence
 from typing import (
     Any,
     Callable,
-    Collection,
-    Iterable,
-    Mapping,
-    MutableMapping,
-    Sequence,
     TypeVar,
 )
 
@@ -140,10 +136,10 @@ def determine_default_max_value(
 
 def determine_max_value(
     bound_arguments: inspect.BoundArguments,
-    args: P.args,
-    kwargs: P.kwargs,
     parameter_name: str,
     default_max_value: int | Callable[P, int] | None,
+    *args: P.args,
+    **kwargs: P.kwargs,
 ) -> int:
     """
     Either use the provided value, or the default maximum value.
@@ -338,11 +334,11 @@ def maximize_memory_utilization_decorator(
             # determine actual max values
             max_values = [
                 determine_max_value(
-                    bound_arguments=bound_arguments,
-                    args=args,
-                    kwargs=kwargs,
-                    parameter_name=name,
-                    default_max_value=default_max_value,
+                    bound_arguments,
+                    name,
+                    default_max_value,
+                    *args,
+                    **kwargs,
                 )
                 for name, default_max_value in default_max_values.items()
             ]

--- a/src/torch_max_mem/version.py
+++ b/src/torch_max_mem/version.py
@@ -8,8 +8,8 @@ from subprocess import CalledProcessError, check_output
 
 __all__ = [
     "VERSION",
-    "get_version",
     "get_git_hash",
+    "get_version",
 ]
 
 VERSION = "0.1.4-dev"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,1 @@
-
 """Tests for :mod:`torch_max_mem`."""

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,7 +1,7 @@
 """Tests."""
 
 import unittest
-from typing import Optional, Tuple
+from typing import Optional
 
 import pytest
 import torch
@@ -65,7 +65,7 @@ def test_parameter_types():
 
 
 @pytest.mark.parametrize("keys", [None, ("a",), ("a", "b", "c")])
-def test_key_hasher(keys: Optional[Tuple[str]]):
+def test_key_hasher(keys: Optional[tuple[str]]):
     """Test ad-hoc hasher."""
 
     def func(a, b, c, batch_size: int):
@@ -154,7 +154,7 @@ def test_oom_error_detection(error: BaseException, exp: bool) -> None:
     assert is_oom_error(error) is exp
 
 
-@pytest.mark.slow()
+@pytest.mark.slow
 def test_large_on_mps():
     """Test memory optimization on a large input."""
     import torch.backends.mps


### PR DESCRIPTION
- Update minimum python to 3.9 since 3.8 is past end of life
- Run modern ruff
- Remove old configuration
- get rid of torch<2.4 old restriction on windows
- fix rtfd config in conf.py
- breaking change in signature of `determine_max_value()` to make mypy happy