### PR TITLE
Update supported Python range to match upstream torch (3.10-3.14)

### DIFF
--- a/.github/actions/setup-uv-python/action.yml
+++ b/.github/actions/setup-uv-python/action.yml
@@ -1,9 +1,8 @@
-name: "Checkout and install uv"
-description: "Checks out the repository and installs uv with dependency caching"
+name: "Install uv"
+description: "Installs uv with dependency caching. Run actions/checkout before this step."
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
     - name: "Install uv"
       uses: "astral-sh/setup-uv@v3"
       with:

--- a/.github/actions/setup-uv-python/action.yml
+++ b/.github/actions/setup-uv-python/action.yml
@@ -1,0 +1,11 @@
+name: "Checkout and install uv"
+description: "Checks out the repository and installs uv with dependency caching"
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v4
+    - name: "Install uv"
+      uses: "astral-sh/setup-uv@v3"
+      with:
+        enable-cache: true
+        cache-dependency-glob: "pyproject.toml"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.13", "3.9" ]
+        python-version: [ "3.14", "3.10" ]
         tox-command: [ "lint", "pyroma", "mypy" ]
     steps:
       - uses: actions/checkout@v4
@@ -46,9 +46,7 @@ jobs:
     strategy:
       matrix:
         # We only test documentation on the latest version
-        # sphinx 8.0 / sphinx-rtd-theme 3.0 discontinued Python 3.9 support
-        # a year early, which prompted re-thinking about this.
-        python-version: [ "3.13" ]
+        python-version: [ "3.14" ]
     steps:
       - uses: actions/checkout@v4
       - name: "Install uv"
@@ -76,7 +74,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ "3.13", "3.9" ]
+        python-version: [ "3.14", "3.10" ]
     steps:
       - uses: actions/checkout@v4
       - name: "Install uv"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,8 +25,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.14", "3.10" ]
-        tox-command: [ "lint", "pyroma", "mypy" ]
+        # lint/pyroma only inspect static config and source text, so their result
+        # is the same regardless of interpreter version; only run them once.
+        # mypy's output does depend on the Python version's typeshed stubs, so
+        # it is checked across the full supported range.
+        include:
+          - python-version: "3.14"
+            tox-command: "lint"
+          - python-version: "3.14"
+            tox-command: "pyroma"
+          - python-version: "3.14"
+            tox-command: "mypy"
+          - python-version: "3.10"
+            tox-command: "mypy"
     steps:
       - uses: actions/checkout@v4
       - name: "Install uv"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,11 @@
 
 name: Tests
 
-# by default, give the GITHUB_TOKEN no permissions
+# by default, give the GITHUB_TOKEN read-only access to the repository contents,
+# which is the only permission any job below requires
 # See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
-permissions: { }
+permissions:
+  contents: read
 
 on:
   push:
@@ -17,11 +19,6 @@ on:
 jobs:
   lint:
     name: Code Quality
-    permissions:
-      # give only read-only access to the contents of the repository
-      # this is the only permission this job requires, so keep it to the least privilege
-      # i.e., not to issues, discussions, actions, etc.
-      contents: read
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -51,13 +48,11 @@ jobs:
 
   docs:
     name: Documentation
-    permissions:
-      contents: read
     runs-on: ubuntu-latest
     strategy:
       matrix:
         # We only test documentation on the latest version
-        python-version: [ "3.14" ]
+        tox-command: [ "docs-lint", "docstr-coverage", "docs-test", "lint-markdown" ]
     steps:
       - uses: actions/checkout@v4
       - name: "Install uv"
@@ -65,26 +60,18 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
-      - name: Install dependencies
-        run: |
-          sudo apt-get install graphviz
-      - name: Lint documentation
-        run: uvx -p ${{ matrix.python-version }} --with tox-uv tox -e docs-lint
-      - name: Check docstring coverage
-        run: uvx -p ${{ matrix.python-version }} --with tox-uv tox -e docstr-coverage
-      - name: Check documentation build with Sphinx
-        run: uvx -p ${{ matrix.python-version }} --with tox-uv tox -e docs-test
-      - name: Lint markdown
-        run: uvx -p ${{ matrix.python-version }} --with tox-uv tox -e lint-markdown
+      - name: Install graphviz
+        # only the Sphinx build needs it
+        if: matrix.tox-command == 'docs-test'
+        run: sudo apt-get install graphviz
+      - name: "Run command"
+        run: uvx -p 3.14 --with tox-uv tox -e ${{ matrix.tox-command }}
 
   tests:
     name: Tests
-    permissions:
-      contents: read
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
         python-version: [ "3.14", "3.10" ]
     steps:
       - uses: actions/checkout@v4
@@ -101,7 +88,6 @@ jobs:
           uvx -p ${{ matrix.python-version }} --with tox-uv tox -e doctests
       - name: Upload coverage report to codecov
         uses: codecov/codecov-action@v4
-        if: success()
         with:
           file: coverage.xml
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,54 +18,67 @@ on:
 
 jobs:
   lint:
-    name: Code Quality
+    name: Lint
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # lint/pyroma only inspect static config and source text, so their result
-        # is the same regardless of interpreter version; only run them once.
-        # mypy's output does depend on the Python version's typeshed stubs, so
-        # it is checked across the full supported range.
-        include:
-          - python-version: "3.14"
-            tox-command: "lint"
-          - python-version: "3.14"
-            tox-command: "pyroma"
-          - python-version: "3.14"
-            tox-command: "mypy"
-          - python-version: "3.10"
-            tox-command: "mypy"
     steps:
-      - uses: actions/checkout@v4
-      - name: "Install uv"
-        uses: "astral-sh/setup-uv@v3"
-        with:
-          enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
-      - name: "Run command"
-        run: |
-          uvx -p ${{ matrix.python-version }} --with tox-uv tox -e ${{ matrix.tox-command }}
+      - uses: ./.github/actions/setup-uv-python
+      - name: Run ruff
+        run: uvx -p 3.14 --with tox-uv tox -e lint
 
-  docs:
-    name: Documentation
+  pyroma:
+    name: Pyroma
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/setup-uv-python
+      - name: Run pyroma
+        run: uvx -p 3.14 --with tox-uv tox -e pyroma
+
+  mypy:
+    name: Mypy
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # We only test documentation on the latest version
-        tox-command: [ "docs-lint", "docstr-coverage", "docs-test", "lint-markdown" ]
+        # mypy's output depends on the Python version's typeshed stubs,
+        # so it is checked across the full supported range
+        python-version: [ "3.14", "3.10" ]
     steps:
-      - uses: actions/checkout@v4
-      - name: "Install uv"
-        uses: "astral-sh/setup-uv@v3"
-        with:
-          enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
+      - uses: ./.github/actions/setup-uv-python
+      - name: Run mypy
+        run: uvx -p ${{ matrix.python-version }} --with tox-uv tox -e mypy
+
+  docs-lint:
+    name: "Docs: Lint"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/setup-uv-python
+      - name: Lint documentation
+        run: uvx -p 3.14 --with tox-uv tox -e docs-lint
+
+  docstr-coverage:
+    name: "Docs: Docstring Coverage"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/setup-uv-python
+      - name: Check docstring coverage
+        run: uvx -p 3.14 --with tox-uv tox -e docstr-coverage
+
+  docs-test:
+    name: "Docs: Build"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/setup-uv-python
       - name: Install graphviz
-        # only the Sphinx build needs it
-        if: matrix.tox-command == 'docs-test'
         run: sudo apt-get install graphviz
-      - name: "Run command"
-        run: uvx -p 3.14 --with tox-uv tox -e ${{ matrix.tox-command }}
+      - name: Check documentation build with Sphinx
+        run: uvx -p 3.14 --with tox-uv tox -e docs-test
+
+  lint-markdown:
+    name: "Docs: Lint Markdown"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/setup-uv-python
+      - name: Lint markdown
+        run: uvx -p 3.14 --with tox-uv tox -e lint-markdown
 
   tests:
     name: Tests
@@ -74,12 +87,7 @@ jobs:
       matrix:
         python-version: [ "3.14", "3.10" ]
     steps:
-      - uses: actions/checkout@v4
-      - name: "Install uv"
-        uses: "astral-sh/setup-uv@v3"
-        with:
-          enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
+      - uses: ./.github/actions/setup-uv-python
       - name: Test with pytest and generate coverage file
         run:
           uvx -p ${{ matrix.python-version }} --with tox-uv tox -e py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-uv-python
       - name: Run ruff
         run: uvx -p 3.14 --with tox-uv tox -e lint
@@ -29,6 +30,7 @@ jobs:
     name: Pyroma
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-uv-python
       - name: Run pyroma
         run: uvx -p 3.14 --with tox-uv tox -e pyroma
@@ -42,6 +44,7 @@ jobs:
         # so it is checked across the full supported range
         python-version: [ "3.14", "3.10" ]
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-uv-python
       - name: Run mypy
         run: uvx -p ${{ matrix.python-version }} --with tox-uv tox -e mypy
@@ -50,6 +53,7 @@ jobs:
     name: "Docs: Lint"
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-uv-python
       - name: Lint documentation
         run: uvx -p 3.14 --with tox-uv tox -e docs-lint
@@ -58,6 +62,7 @@ jobs:
     name: "Docs: Docstring Coverage"
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-uv-python
       - name: Check docstring coverage
         run: uvx -p 3.14 --with tox-uv tox -e docstr-coverage
@@ -66,6 +71,7 @@ jobs:
     name: "Docs: Build"
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-uv-python
       - name: Install graphviz
         run: sudo apt-get install graphviz
@@ -76,6 +82,7 @@ jobs:
     name: "Docs: Lint Markdown"
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-uv-python
       - name: Lint markdown
         run: uvx -p 3.14 --with tox-uv tox -e lint-markdown
@@ -87,6 +94,7 @@ jobs:
       matrix:
         python-version: [ "3.14", "3.10" ]
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-uv-python
       - name: Test with pytest and generate coverage file
         run:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ brute-force distance calculation.
 ```python
 import torch
 
+
 def knn(x, y, batch_size, k: int = 3):
     return torch.cat(
         [

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,14 +13,14 @@ root, use ``os.path.abspath`` to make it absolute, like shown here.
 import os
 import re
 import sys
-from datetime import date
+from datetime import datetime, timezone
 
 sys.path.insert(0, os.path.abspath("../../src"))
 
 # -- Project information -----------------------------------------------------
 
 project = "torch_max_mem"
-copyright = f"{date.today().year}, Max Berrendorf"
+copyright = f"{datetime.now(tz=timezone.utc).date().year}, Max Berrendorf"
 author = "Max Berrendorf"
 
 # The full version, including alpha/beta/rc tags.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,11 @@ classifiers = [
     "Framework :: tox",
     "Framework :: Sphinx",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
     # TODO add your topics from the Trove controlled vocabulary (see https://pypi.org/classifiers)
 ]
@@ -40,7 +40,7 @@ keywords = [
 # See PEP-639 at https://peps.python.org/pep-0639/#add-license-files-key
 license-files = ["LICENSE"]
 
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = ["torch>=2.0", "typing_extensions"]
 
 # see https://peps.python.org/pep-0735/ and https://docs.astral.sh/uv/concepts/dependencies/#dependency-groups

--- a/src/torch_max_mem/api.py
+++ b/src/torch_max_mem/api.py
@@ -53,10 +53,9 @@ import functools
 import inspect
 import itertools
 import logging
-from collections.abc import Collection, Iterable, Mapping, MutableMapping, Sequence
+from collections.abc import Callable, Collection, Iterable, Mapping, MutableMapping, Sequence
 from typing import (
     Any,
-    Callable,
     TypeVar,
 )
 
@@ -350,7 +349,7 @@ def maximize_memory_utilization_decorator(
 
             while i < len(max_values):
                 while max_values[i] > 0:
-                    p_kwargs = dict(zip(parameter_names, max_values))
+                    p_kwargs = dict(zip(parameter_names, max_values, strict=False))
                     # note: changes to arguments apply to both, .args and .kwargs
                     bound_arguments.arguments.update(p_kwargs)
                     try:
@@ -358,7 +357,7 @@ def maximize_memory_utilization_decorator(
                     except (torch.cuda.OutOfMemoryError, RuntimeError) as error:
                         # raise errors unrelated to out-of-memory
                         if not is_oom_error(error):
-                            raise error
+                            raise
 
                         # clear cache
                         if torch.cuda.is_available():
@@ -490,7 +489,7 @@ class MemoryUtilizationMaximizer:
                 bound.apply_defaults()
                 # todo: default logic?
                 values = tuple(bound.arguments[name] for name in self.parameter_names)
-            kwargs.update(zip(self.parameter_names, values))
+            kwargs.update(zip(self.parameter_names, values, strict=False))
             result, self.parameter_value[h] = wrapped(*args, **kwargs)
             return result
 

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,7 +1,7 @@
 """Tests."""
 
 import unittest
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 import torch
@@ -69,12 +69,11 @@ def test_parameter_types() -> None:
 
 
 @pytest.mark.parametrize("keys", [None, ("a",), ("a", "b", "c")])
-def test_key_hasher(keys: Optional[tuple[str, ...]]) -> None:
+def test_key_hasher(keys: tuple[str, ...] | None) -> None:
     """Test ad-hoc hasher."""
 
     def func(a: Any, b: Any, c: Any, batch_size: int) -> None:
         """Test function."""
-        pass
 
     wrapped = maximize_memory_utilization(keys=keys)(func)
     wrapped(a=1, b=3, c=7, batch_size=2)


### PR DESCRIPTION
## Summary
- torch 2.13 (latest on PyPI) requires Python `>=3.10` and now supports up through 3.14. Drops the unsupported Python 3.9 floor and adds 3.14 to `requires-python` and the trove classifiers.
- Fixes pre-existing lint violations (`DTZ011`, `TRY201`, `PIE790`, a README formatting nit) surfaced by ruff 0.16.2, which hadn't actually run in CI in over a year - not new issues introduced by this PR.
- Restructures `.github/workflows/tests.yml` for clarity and less duplication:
  - Hoists the identical `contents: read` permission to the workflow level instead of repeating it per job.
  - Splits the old matrix-of-tox-command "Code Quality" and "Documentation" jobs into separate named jobs (`Lint`, `Pyroma`, `Mypy`, `Docs: Lint`, `Docs: Docstring Coverage`, `Docs: Build`, `Docs: Lint Markdown`) since most of them don't vary by Python version - only `Mypy` keeps a `python-version` matrix, since typeshed stubs differ by version.
  - Drops the `tests` job's single-element `os` matrix (leftover from the stalled #19 macOS/Windows attempt).
  - Adds `.github/actions/setup-uv-python`, a small composite action wrapping the uv install/cache step, to avoid repeating it across the now-larger number of jobs.

## Test plan
- [x] CI passes on all jobs (lint, pyroma, mypy x2, docs x4, tests x2)