### PR TITLE
Add infer_maximum_batch_size decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ knn(x, y, batch_size=x.shape[0])
 ```
 
 If you would rather not have to pass the batch size explicitly at all, you can
-additionally decorate the function with `infer_maximum_batch_size`, which
-infers it from the length of another parameter (`x` by default) whenever
-`batch_size` is not given explicitly
+additionally decorate the function with `infer_maximum_batch_size`, which infers
+it from the length of another parameter (`x` by default) whenever `batch_size`
+is not given explicitly
 ([source](https://github.com/mberr/torch-max-mem/issues/14#issuecomment-5237588056)).
 
 ```python

--- a/README.md
+++ b/README.md
@@ -83,6 +83,34 @@ y = torch.rand(200, 100, device="cuda")
 knn(x, y, batch_size=x.shape[0])
 ```
 
+If you would rather not have to pass the batch size explicitly at all, you can
+additionally decorate the function with `infer_maximum_batch_size`, which
+infers it from the length of another parameter (`x` by default) whenever
+`batch_size` is not given explicitly
+([source](https://github.com/mberr/torch-max-mem/issues/14#issuecomment-5237588056)).
+
+```python
+import torch
+from torch_max_mem import infer_maximum_batch_size, maximize_memory_utilization
+
+
+@infer_maximum_batch_size()
+@maximize_memory_utilization()
+def knn(x, y, batch_size, k: int = 3):
+    return torch.cat(
+        [
+            torch.cdist(x[start : start + batch_size], y).topk(k=k, dim=1, largest=False).indices
+            for start in range(0, x.shape[0], batch_size)
+        ],
+        dim=0,
+    )
+
+
+x = torch.rand(100, 100, device="cuda")
+y = torch.rand(200, 100, device="cuda")
+knn(x, y)
+```
+
 ## 🚀 Installation
 
 The most recent release can be installed from

--- a/src/torch_max_mem/__init__.py
+++ b/src/torch_max_mem/__init__.py
@@ -1,8 +1,9 @@
 """Maximize memory utilization with PyTorch."""
 
-from .api import MemoryUtilizationMaximizer, maximize_memory_utilization
+from .api import MemoryUtilizationMaximizer, infer_maximum_batch_size, maximize_memory_utilization
 
 __all__ = [
     "MemoryUtilizationMaximizer",
+    "infer_maximum_batch_size",
     "maximize_memory_utilization",
 ]

--- a/src/torch_max_mem/api.py
+++ b/src/torch_max_mem/api.py
@@ -65,6 +65,7 @@ from typing_extensions import ParamSpec
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    "infer_maximum_batch_size",
     "maximize_memory_utilization",
 ]
 
@@ -384,6 +385,87 @@ def maximize_memory_utilization_decorator(
         return wrapper_maximize_memory_utilization
 
     return decorator_maximize_memory_utilization
+
+
+# cf. https://github.com/mberr/torch-max-mem/issues/14#issuecomment-5237588056
+def infer_maximum_batch_size(
+    parameter_name: str = "batch_size",
+    x_parameter_name: str = "x",
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    """
+    Create a decorator that infers a maximum batch size from the size of another parameter.
+
+    This is useful to combine with :func:`maximize_memory_utilization`, so the batch size parameter does not need to
+    be passed explicitly on each call.
+
+    .. code-block:: python
+
+        from torch_max_mem import infer_maximum_batch_size, maximize_memory_utilization
+
+
+        @infer_maximum_batch_size()
+        @maximize_memory_utilization()
+        def knn(x, y, batch_size, k: int = 3):
+            return torch.cat(
+                [
+                    torch.cdist(x[start : start + batch_size], y).topk(k=k, dim=1, largest=False).indices
+                    for start in range(0, x.shape[0], batch_size)
+                ],
+                dim=0,
+            )
+
+    :param parameter_name:
+        The name of the batch size parameter to infer, if it is not explicitly given (or ``None``).
+    :param x_parameter_name:
+        The name of the parameter whose length, cf. :func:`len`, is used to infer the batch size.
+
+    :return:
+        A decorator for functions.
+
+    :raises ValueError:
+        when the function does not have a parameter of the name ``x_parameter_name``
+    """
+
+    def decorator_infer_maximum_batch_size(func: Callable[P, R]) -> Callable[P, R]:
+        """
+        Decorate a function to infer its maximum batch size from another parameter.
+
+        :param func:
+            The function to decorate.
+
+        :return:
+            The decorated function.
+
+        :raises ValueError:
+            when the function does not have a parameter of the name ``x_parameter_name``
+        """
+        signature = inspect.signature(func)
+        if x_parameter_name not in signature.parameters:
+            raise ValueError(f"{func} does not have a parameter {x_parameter_name}.")
+
+        @functools.wraps(func)
+        def wrapper_infer_maximum_batch_size(*args: P.args, **kwargs: P.kwargs) -> R:
+            """
+            Wrap a function to infer the maximum batch size from another parameter, unless explicitly given.
+
+            :param args:
+                The positional arguments.
+            :param kwargs:
+                The key-word based arguments.
+
+            :return:
+                The result of calling the wrapped function.
+            """
+            bound_arguments = signature.bind_partial(*args, **kwargs)
+            if bound_arguments.arguments.get(parameter_name) is None:
+                # inject the inferred value as a keyword argument, leaving the original call shape untouched, so
+                # that, e.g., stacking with :func:`maximize_memory_utilization` keeps working correctly
+                kwargs[parameter_name] = len(bound_arguments.arguments[x_parameter_name])
+            return func(*args, **kwargs)
+
+        return wrapper_infer_maximum_batch_size
+
+    return decorator_infer_maximum_batch_size
 
 
 class KeyHasher:

--- a/src/torch_max_mem/api.py
+++ b/src/torch_max_mem/api.py
@@ -391,6 +391,7 @@ def maximize_memory_utilization_decorator(
 def infer_maximum_batch_size(
     parameter_name: str = "batch_size",
     x_parameter_name: str = "x",
+    max_value: int | None = None,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """
     Create a decorator that infers a maximum batch size from the size of another parameter.
@@ -418,6 +419,9 @@ def infer_maximum_batch_size(
         The name of the batch size parameter to infer, if it is not explicitly given (or ``None``).
     :param x_parameter_name:
         The name of the parameter whose length, cf. :func:`len`, is used to infer the batch size.
+    :param max_value:
+        An optional upper bound for the inferred batch size, e.g., to avoid starting out with an unreasonably large
+        value even though the input is large. Has no effect on an explicitly given batch size.
 
     :return:
         A decorator for functions.
@@ -458,9 +462,12 @@ def infer_maximum_batch_size(
             """
             bound_arguments = signature.bind_partial(*args, **kwargs)
             if bound_arguments.arguments.get(parameter_name) is None:
+                inferred_value = len(bound_arguments.arguments[x_parameter_name])
+                if max_value is not None:
+                    inferred_value = min(inferred_value, max_value)
                 # inject the inferred value as a keyword argument, leaving the original call shape untouched, so
                 # that, e.g., stacking with :func:`maximize_memory_utilization` keeps working correctly
-                kwargs[parameter_name] = len(bound_arguments.arguments[x_parameter_name])
+                kwargs[parameter_name] = inferred_value
             return func(*args, **kwargs)
 
         return wrapper_infer_maximum_batch_size

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -105,6 +105,23 @@ def test_infer_maximum_batch_size() -> None:
     assert func(list(range(5)), batch_size=2) == 2
 
 
+def test_infer_maximum_batch_size_max_value() -> None:
+    """Test that the inferred batch size is capped at max_value."""
+
+    @infer_maximum_batch_size(max_value=3)
+    def func(x: Sequence[Any], batch_size: int | None = None) -> int:
+        """Return the batch size."""
+        assert batch_size is not None
+        return batch_size
+
+    # inferred value is capped
+    assert func(list(range(5))) == 3
+    # smaller inferred value is untouched
+    assert func(list(range(2))) == 2
+    # an explicitly given batch size is not capped
+    assert func(list(range(5)), batch_size=4) == 4
+
+
 def test_infer_maximum_batch_size_custom_names() -> None:
     """Test batch size inference with non-default parameter names."""
 

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,12 +1,13 @@
 """Tests."""
 
 import unittest
+from collections.abc import Sequence
 from typing import Any
 
 import pytest
 import torch
 
-from torch_max_mem import maximize_memory_utilization
+from torch_max_mem import infer_maximum_batch_size, maximize_memory_utilization
 from torch_max_mem.api import floor_to_nearest_multiple_of, is_oom_error, maximize_memory_utilization_decorator
 
 
@@ -88,6 +89,58 @@ def test_default_no_arg() -> None:
 
     # call with no arg
     func()
+
+
+def test_infer_maximum_batch_size() -> None:
+    """Test batch size inference from another parameter's length."""
+
+    @infer_maximum_batch_size()
+    def func(x: Sequence[Any], batch_size: int | None = None) -> int:
+        """Return the batch size."""
+        assert batch_size is not None
+        return batch_size
+
+    assert func(list(range(5))) == 5
+    # an explicitly given batch size is not overridden
+    assert func(list(range(5)), batch_size=2) == 2
+
+
+def test_infer_maximum_batch_size_custom_names() -> None:
+    """Test batch size inference with non-default parameter names."""
+
+    @infer_maximum_batch_size(parameter_name="chunk_size", x_parameter_name="y")
+    def func(y: Sequence[Any], chunk_size: int | None = None) -> int:
+        """Return the chunk size."""
+        assert chunk_size is not None
+        return chunk_size
+
+    assert func(list(range(7))) == 7
+
+
+def test_infer_maximum_batch_size_missing_parameter() -> None:
+    """Test that decoration fails if the length parameter does not exist."""
+    with pytest.raises(ValueError, match="does not have a parameter"):
+
+        @infer_maximum_batch_size(x_parameter_name="does_not_exist")
+        def func(x: Sequence[Any], batch_size: int | None = None) -> None:
+            """Test function."""
+
+
+def test_infer_maximum_batch_size_stacked() -> None:
+    """Test combining batch size inference with memory utilization maximization."""
+    x = torch.rand(100, 100)
+    y = torch.rand(200, 100)
+
+    @infer_maximum_batch_size()
+    @maximize_memory_utilization()
+    def wrapped_knn(x: torch.Tensor, y: torch.Tensor, batch_size: int, k: int = 3) -> torch.Tensor:
+        """Compute k-nearest neighbors via batched brute-force distance calculation."""
+        return knn(x, y, batch_size, k=k)
+
+    reference = knn(x, y, batch_size=x.shape[0])
+    optimized = wrapped_knn(x, y)
+    assert reference.shape == optimized.shape
+    assert torch.allclose(reference, optimized)
 
 
 def test_optimization() -> None:

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -155,7 +155,9 @@ def test_infer_maximum_batch_size_stacked() -> None:
         return knn(x, y, batch_size, k=k)
 
     reference = knn(x, y, batch_size=x.shape[0])
-    optimized = wrapped_knn(x, y)
+    # infer_maximum_batch_size preserves the wrapped function's ParamSpec, so mypy still considers batch_size
+    # required here, even though it is optional at runtime
+    optimized = wrapped_knn(x, y)  # type: ignore[call-arg]
     assert reference.shape == optimized.shape
     assert torch.allclose(reference, optimized)
 


### PR DESCRIPTION
## Summary
- Adds a new `infer_maximum_batch_size` decorator that infers a `batch_size` parameter from `len(x)` when not explicitly given, meant to be stacked with `maximize_memory_utilization` so callers don't need to pass `batch_size` on every call.
- Adds an optional `max_value` to cap the inferred batch size (added as a separate commit).

Based on the decorator suggested by @cthoyt in #14 (comment), generalized to use `len()` instead of `.shape[0]` so it also works with plain sequences, not just tensors.

## Test plan
- [x] `uv run --group tests pytest tests/test_decorator.py -m "not slow"` — all pass
- [x] `uv run --group lint ruff check` / `ruff format --check` — clean
- [x] `uv run --group typing mypy src/torch_max_mem/api.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)